### PR TITLE
Fix import error bug

### DIFF
--- a/VGG16 in Keras.ipynb
+++ b/VGG16 in Keras.ipynb
@@ -3357,7 +3357,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from keras.optimizers import Adam\n",
+    "from tensorflow.keras.optimizers import Adam\n",
     "opt = Adam(lr=0.001)\n",
     "model.compile(optimizer=opt, loss=keras.losses.categorical_crossentropy, metrics=['accuracy'])"
    ]


### PR DESCRIPTION
Importing Adam optimizer will not work after the last Keras API update(2.5.0) and will show the Import Error bug. So I replaced it with `from tensorflow.keras.optimizers import Adam` which works fine.